### PR TITLE
Highlight square on chessboard click

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import ChessBoard from "./components/ChessBoard.vue";
+import HighlightBoard from "./components/HighlightBoard.vue";
 import SideBar from "./components/SideBar.vue";
 </script>
 
 <template>
   <div class="app">
     <main>
-      <ChessBoard />
+      <div class="wrapper">
+        <ChessBoard />
+        <HighlightBoard />
+      </div>
     </main>
     <aside>
       <SideBar />
@@ -15,6 +19,9 @@ import SideBar from "./components/SideBar.vue";
 </template>
 
 <style scoped>
+.wrapper {
+  position: relative;
+}
 .app {
   display: grid;
   grid-template-columns: 1fr 300px;

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import { store } from "@/store.ts";
 import HighlightSquare from "./HighlightSquare.vue";
+import { Coordinate } from "@/types";
 const getSquareClass = (row: number, column: number): string => {
   return (row + column) % 2 === 0 ? "light" : "dark";
 };
+function handleSquareClick(row: number, column: number) {
+  const coordinate: Coordinate = { file: column, rank: row };
+  store.highlighted.push(coordinate);
+}
 </script>
 
 <template>
@@ -15,6 +20,7 @@ const getSquareClass = (row: number, column: number): string => {
           :key="`${row}${column}`"
           class="square"
           :class="getSquareClass(row, column)"
+          @click="handleSquareClick(row, column)"
         />
       </template>
     </div>
@@ -46,10 +52,12 @@ const getSquareClass = (row: number, column: number): string => {
   bottom: 0;
   left: 0;
   right: 0;
+  pointer-events: none;
 }
 .highlight :deep(.square) {
   background-color: rgb(235, 97, 80);
   opacity: 0.8;
+  pointer-events: auto;
 }
 .light {
   background-color: #eeeed2;

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -6,7 +6,7 @@ const getSquareClass = (row: number, column: number): string => {
 };
 function handleSquareClick(row: number, column: number) {
   const coordinate: Coordinate = { file: column, rank: row };
-  store.highlighted.push(coordinate);
+  store.addHighlight(coordinate);
 }
 </script>
 

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -6,14 +6,14 @@ const getSquareClass = (row: number, column: number): string => {
 
 <template>
   <div class="board">
-    <div v-for="row in 8" :key="row" class="rank">
+    <template v-for="row in 8">
       <div
         v-for="column in 8"
-        :key="column"
+        :key="`${row}${column}`"
         class="square"
         :class="getSquareClass(row, column)"
       />
-    </div>
+    </template>
   </div>
 </template>
 
@@ -22,16 +22,9 @@ const getSquareClass = (row: number, column: number): string => {
   max-width: 100vh;
   margin: auto;
   aspect-ratio: 1;
-  display: flex;
-  flex-direction: column;
-}
-.rank {
-  display: flex;
-  flex: 1;
-}
-.square {
-  display: inline-block;
-  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(8, 1fr);
 }
 .light {
   background-color: #eeeed2;

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -5,19 +5,27 @@ const getSquareClass = (row: number, column: number): string => {
 </script>
 
 <template>
-  <div class="board">
-    <template v-for="row in 8">
-      <div
-        v-for="column in 8"
-        :key="`${row}${column}`"
-        class="square"
-        :class="getSquareClass(row, column)"
-      />
-    </template>
+  <div class="wrapper">
+    <div class="board">
+      <template v-for="row in 8">
+        <div
+          v-for="column in 8"
+          :key="`${row}${column}`"
+          class="square"
+          :class="getSquareClass(row, column)"
+        />
+      </template>
+    </div>
+    <div class="board highlight">
+      <div class="square"></div>
+    </div>
   </div>
 </template>
 
 <style scoped>
+.wrapper {
+  position: relative;
+}
 .board {
   max-width: 100vh;
   margin: auto;
@@ -25,6 +33,19 @@ const getSquareClass = (row: number, column: number): string => {
   display: grid;
   grid-template-columns: repeat(8, 1fr);
   grid-template-rows: repeat(8, 1fr);
+}
+.highlight {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+.highlight .square {
+  grid-column-start: 4;
+  grid-row-start: 4;
+  background-color: rgb(235, 97, 80);
+  opacity: 0.8;
 }
 .light {
   background-color: #eeeed2;

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -25,14 +25,8 @@ function handleSquareClick(row: number, column: number) {
 </template>
 
 <style scoped>
-:global(.board) {
-  max-width: 100vh;
-  margin: auto;
-  aspect-ratio: 1;
-  display: grid;
-  grid-template-columns: repeat(8, 1fr);
-  grid-template-rows: repeat(8, 1fr);
-}
+@import "@/styles/board.css";
+
 .light {
   background-color: #eeeed2;
 }

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { store } from "@/store.ts";
-import HighlightSquare from "./HighlightSquare.vue";
 import { Coordinate } from "@/types";
+import HighlightBoard from "./HighlightBoard.vue";
 const getSquareClass = (row: number, column: number): string => {
   return (row + column) % 2 === 0 ? "light" : "dark";
 };
@@ -24,13 +24,7 @@ function handleSquareClick(row: number, column: number) {
         />
       </template>
     </div>
-    <div class="board highlight">
-      <HighlightSquare
-        v-for="square in store.highlighted"
-        :key="square"
-        :coordinate="square"
-      />
-    </div>
+    <HighlightBoard />
   </div>
 </template>
 
@@ -45,19 +39,6 @@ function handleSquareClick(row: number, column: number) {
   display: grid;
   grid-template-columns: repeat(8, 1fr);
   grid-template-rows: repeat(8, 1fr);
-}
-.highlight {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  pointer-events: none;
-}
-.highlight :deep(.square) {
-  background-color: rgb(235, 97, 80);
-  opacity: 0.8;
-  pointer-events: auto;
 }
 .light {
   background-color: #eeeed2;

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { store } from "@/store.ts";
 import { Coordinate } from "@/types";
-import HighlightBoard from "./HighlightBoard.vue";
 const getSquareClass = (row: number, column: number): string => {
   return (row + column) % 2 === 0 ? "light" : "dark";
 };
@@ -12,27 +11,21 @@ function handleSquareClick(row: number, column: number) {
 </script>
 
 <template>
-  <div class="wrapper">
-    <div class="board">
-      <template v-for="row in 8">
-        <div
-          v-for="column in 8"
-          :key="`${row}${column}`"
-          class="square"
-          :class="getSquareClass(row, column)"
-          @click="handleSquareClick(row, column)"
-        />
-      </template>
-    </div>
-    <HighlightBoard />
+  <div class="board">
+    <template v-for="row in 8">
+      <div
+        v-for="column in 8"
+        :key="`${row}${column}`"
+        class="square"
+        :class="getSquareClass(row, column)"
+        @click="handleSquareClick(row, column)"
+      />
+    </template>
   </div>
 </template>
 
 <style scoped>
-.wrapper {
-  position: relative;
-}
-.board {
+:global(.board) {
   max-width: 100vh;
   margin: auto;
   aspect-ratio: 1;

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { store } from "@/store.ts";
+import HighlightSquare from "./HighlightSquare.vue";
 const getSquareClass = (row: number, column: number): string => {
   return (row + column) % 2 === 0 ? "light" : "dark";
 };
@@ -17,7 +19,11 @@ const getSquareClass = (row: number, column: number): string => {
       </template>
     </div>
     <div class="board highlight">
-      <div class="square"></div>
+      <HighlightSquare
+        v-for="square in store.highlighted"
+        :key="square"
+        :coordinate="square"
+      />
     </div>
   </div>
 </template>
@@ -41,9 +47,7 @@ const getSquareClass = (row: number, column: number): string => {
   left: 0;
   right: 0;
 }
-.highlight .square {
-  grid-column-start: 4;
-  grid-row-start: 4;
+.highlight :deep(.square) {
   background-color: rgb(235, 97, 80);
   opacity: 0.8;
 }

--- a/src/components/HighlightBoard.vue
+++ b/src/components/HighlightBoard.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
 import { store } from "@/store.ts";
 import HighlightSquare from "./HighlightSquare.vue";
+import { Coordinate } from "@/types";
+
+function key(square: Coordinate) {
+  return `${square.file}${square.rank}`;
+}
 </script>
 <template>
   <div class="board highlight">
     <HighlightSquare
       v-for="square in store.highlighted"
-      :key="square"
+      :key="key(square)"
       :coordinate="square"
     />
   </div>

--- a/src/components/HighlightBoard.vue
+++ b/src/components/HighlightBoard.vue
@@ -16,7 +16,9 @@ function key(square: Coordinate) {
     />
   </div>
 </template>
-<style>
+<style scoped>
+@import "@/styles/board.css";
+
 .highlight {
   position: absolute;
   top: 0;

--- a/src/components/HighlightBoard.vue
+++ b/src/components/HighlightBoard.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { store } from "@/store.ts";
+import HighlightSquare from "./HighlightSquare.vue";
+</script>
+<template>
+  <div class="board highlight">
+    <HighlightSquare
+      v-for="square in store.highlighted"
+      :key="square"
+      :coordinate="square"
+    />
+  </div>
+</template>
+<style>
+.highlight {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+}
+</style>

--- a/src/components/HighlightSquare.vue
+++ b/src/components/HighlightSquare.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { Coordinate } from "@/types";
+const props = defineProps<{
+  coordinate: Coordinate;
+}>();
+
+function file() {
+  return props.coordinate.file;
+}
+function rank() {
+  return props.coordinate.rank;
+}
+</script>
+<template>
+  <div class="square"></div>
+</template>
+
+<style scoped>
+.square {
+  grid-column-start: v-bind(file());
+  grid-row-start: v-bind(rank());
+}
+</style>

--- a/src/components/HighlightSquare.vue
+++ b/src/components/HighlightSquare.vue
@@ -19,5 +19,8 @@ function rank() {
 .square {
   grid-column-start: v-bind(file());
   grid-row-start: v-bind(rank());
+  background-color: rgb(235, 97, 80);
+  opacity: 0.8;
+  pointer-events: auto;
 }
 </style>

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,8 +3,12 @@ import { Coordinate } from "./types";
 
 type storeType = {
   highlighted: Array<Coordinate>;
+  addHighlight: (coordinate: Coordinate) => void;
 };
 
 export const store = reactive<storeType>({
   highlighted: [],
+  addHighlight(coordinate: Coordinate) {
+    this.highlighted.push(coordinate);
+  },
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,10 @@
+import { reactive } from "vue";
+import { Coordinate } from "./types";
+
+type storeType = {
+  highlighted: Array<Coordinate>;
+};
+
+export const store = reactive<storeType>({
+  highlighted: [],
+});

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1,0 +1,8 @@
+.board {
+  max-width: 100vh;
+  margin: auto;
+  aspect-ratio: 1;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(8, 1fr);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type Coordinate = { file: number; rank: number };


### PR DESCRIPTION
## Description
Addresses:

 5. Clicking a chessboard square should highlight the square.
 6. Keep track of which squares are clicked and the order in which they're clicked.

We are leveraging the [Reactivity API](https://vuejs.org/guide/scaling-up/state-management.html#simple-state-management-with-reactivity-api) to create a `store`. This helps us keep track of all the clicked squares across the app. By doing this, we will establish a solid groundwork for the next requirement (displaying the clicked squares on the `SideBar`) and help us avoid [prop drilling](https://vuejs.org/guide/components/provide-inject.html#prop-drilling).

The board itself was changed to use `display: grid`. This way we can leverage the `grid-column-start` and `grid-row-start` properties on the `HighlightSquare` component to create only 1 HTML element for each saved click square.


## Thought Process
Initially I was thinking on having the highlight be a part of the existing `ChessBoard` square, but I figured it would be too crowded as it would have to handle its specific color (light/dark) logic, the highlighting and possibly the letter/numbers in the future.

This led me to create a separate `HighlightSquare` component that would only care about displaying the highlight.
At first I intended to have the instantiation of these `HighlightSquare`s directly inside the `ChessBoard` component. However, this also would also result in extra clutter for the `ChessBoard`.

After checking around how the highlight logic is being handled at [Chess.com analysis board](https://www.chess.com/analysis), I decided to create a `HighlightBoard` as a sibling of `ChessBoard`. The `HighlightBoard` component only handles the instantiation of `HighlightSquare`s. This ensures a separation of concerns, which makes our code more maintainable and modular.


## Screenshot
![May-05-2023 22-16-22](https://user-images.githubusercontent.com/3190666/236596022-07955a64-0662-48f4-bd0e-e07041049279.gif)
