### PR TITLE
Implement SideBar responsiveness

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,7 +19,12 @@ import SideBar from "./components/SideBar.vue";
 </template>
 
 <style scoped>
+main {
+  display: flex;
+  align-items: center;
+}
 .wrapper {
+  flex: 1;
   position: relative;
 }
 .app {

--- a/src/App.vue
+++ b/src/App.vue
@@ -27,4 +27,11 @@ import SideBar from "./components/SideBar.vue";
   grid-template-columns: 1fr 300px;
   height: 100vh;
 }
+
+@media (max-aspect-ratio: 1/1) {
+  .app {
+    grid-template-columns: auto;
+    grid-template-rows: min-content 1fr;
+  }
+}
 </style>

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -23,10 +23,8 @@ const files: Array<FileLetter> = ["a", "b", "c", "d", "e", "f", "g", "h"];
 </template>
 
 <style scoped lang="scss">
+@import "@/styles/board.css";
 .board {
-  max-width: 100vh;
-  margin: auto;
-  aspect-ratio: 1;
   display: flex;
   flex-direction: column-reverse;
 }

--- a/src/components/HighlightBoard.vue
+++ b/src/components/HighlightBoard.vue
@@ -23,6 +23,8 @@ function key(square: Coordinate) {
 
 .highlight {
   position: absolute;
+  width: 100%;
+  height: 100%;
   top: 0;
   bottom: 0;
   left: 0;

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -10,7 +10,7 @@ import { store } from "@/store.ts";
 <style scoped>
 .sidebar {
   background-color: var(--dark-secondary);
-  height: 100vh;
+  height: 100%;
 }
 @media (prefers-color-scheme: light) {
   .sidebar {

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -13,3 +13,9 @@
     "a2 b2 c2 d2 e2 f2 g2 h2"
     "a1 b1 c1 d1 e1 f1 g1 h1";
 }
+
+@media (max-aspect-ratio: 1/1) {
+  .board {
+    max-width: calc(100vh - 200px);
+  }
+}


### PR DESCRIPTION
## Description
The SideBar will now move to the bottom when the viewport is on landscape mode.
Additionally, we are centering the board vertically when possible.

For Safari, it was necessary to set `width` and `height` to `100%` in addition to the existing `top`, `bottom`, `left`, `right` properties. These rules are used by the `HighlightBoard` so it can be on top of the `ChessBoard`.

It is important to point out that both the `HighlightBoard` and `ChessBoard` share the styles on the `board.css`. Having the sizing and positioning rules for both of them here helps us make sure they remain the same size and on top of each other.

## Screenshot
![May-08-2023 09-48-42](https://user-images.githubusercontent.com/3190666/236856016-ba2d14d8-f7dc-41c5-842b-ce2426b234da.gif)

## Devices tested
✅ Firefox (macOS)
✅ Chrome (macOS)
✅ Chrome (Android)
✅ Safari (macOS)
✅ Safari (iOS)
