### PR TITLE
Show clicked squares on sidebar

### DIFF
--- a/src/components/ClickedHistory.vue
+++ b/src/components/ClickedHistory.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { store } from "@/store.ts";
+import { Coordinate } from "@/types";
+
+const displayCoordinate = (square: Coordinate) =>
+  `${square.file}${square.rank}`;
+</script>
+
+<template>
+  <div class="container">
+    <h3>Square History</h3>
+    <ol>
+      <li
+        v-for="square in store.highlighted"
+        v-bind="square"
+        :key="displayCoordinate(square)"
+      >
+        <span>{{ displayCoordinate(square) }}</span>
+      </li>
+    </ol>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.container {
+  padding: 8px;
+}
+h3 {
+  margin-top: 0;
+}
+ol {
+  margin: 0;
+}
+</style>

--- a/src/components/ClickedHistory.vue
+++ b/src/components/ClickedHistory.vue
@@ -15,7 +15,7 @@ const displayCoordinate = (square: Coordinate) =>
         v-bind="square"
         :key="displayCoordinate(square)"
       >
-        <span>{{ displayCoordinate(square) }}</span>
+        <span class="notation">{{ displayCoordinate(square) }}</span>
       </li>
     </ol>
   </div>
@@ -30,5 +30,8 @@ h3 {
 }
 ol {
   margin: 0;
+}
+.notation {
+  font-weight: bolder;
 }
 </style>

--- a/src/components/ClickedHistory.vue
+++ b/src/components/ClickedHistory.vue
@@ -24,6 +24,9 @@ const displayCoordinate = (square: Coordinate) =>
 <style scoped lang="scss">
 .container {
   padding: 8px;
+  box-sizing: border-box;
+  max-height: 100vh;
+  overflow-y: auto;
 }
 h3 {
   margin-top: 0;
@@ -33,5 +36,12 @@ ol {
 }
 .notation {
   font-weight: bolder;
+}
+
+@media (max-aspect-ratio: 1/1) {
+  .container {
+    max-height: 100%;
+    overflow-y: unset;
+  }
 }
 </style>

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { store } from "@/store.ts";
+import ClickedHistory from "./ClickedHistory.vue";
 </script>
 
 <template>
-  <!-- Temporary rudimentary visualization for easier verification-->
-  <div class="sidebar">{{ JSON.stringify(store.highlighted) }}</div>
+  <div class="sidebar">
+    <ClickedHistory />
+  </div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Description
Given that we were already storing the clicks on the `store`. We just had to create the displaying component.

There is a scroll bar on y-axis for the history when it overflows. This is currently only being used on the portrait mode though. The portrait view relies on scrolling the whole view. We can iterate on this to further improve the UX in a subsequent PR.

## Screenshot
![May-08-2023 13-24-51](https://user-images.githubusercontent.com/3190666/236901831-2689ce09-420d-45c4-a930-a658ea43110a.gif)
