### PR TITLE
Add Rank and File display

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import ChessBoard from "./components/ChessBoard.vue";
 import HighlightBoard from "./components/HighlightBoard.vue";
+import FileRankInfo from "./components/FileRankInfo.vue";
 import SideBar from "./components/SideBar.vue";
 </script>
 
@@ -9,6 +10,7 @@ import SideBar from "./components/SideBar.vue";
     <main>
       <div class="wrapper">
         <ChessBoard />
+        <FileRankInfo />
         <HighlightBoard />
       </div>
     </main>

--- a/src/components/ChessBoard.vue
+++ b/src/components/ChessBoard.vue
@@ -35,17 +35,17 @@ const files: Array<FileLetter> = ["a", "b", "c", "d", "e", "f", "g", "h"];
 
   .square {
     flex: 1;
-    background-color: #769656;
+    background-color: var(--chess-dark);
     &:nth-child(odd) {
-      background-color: #eeeed2;
+      background-color: var(--chess-light);
     }
   }
 }
 .rank:nth-child(odd) {
   .square {
-    background-color: #eeeed2;
+    background-color: var(--chess-light);
     &:nth-child(odd) {
-      background-color: #769656;
+      background-color: var(--chess-dark);
     }
   }
 }

--- a/src/components/FileRankInfo.vue
+++ b/src/components/FileRankInfo.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts"></script>
+
+<template>
+  <svg viewBox="0 0 100 100" class="overlay">
+    <text x=".75" y="3.5" font-size="2.8" class="coordinate-light">8</text>
+    <text x=".75" y="15.75" font-size="2.8" class="coordinate-dark">7</text>
+    <text x=".75" y="28.25" font-size="2.8" class="coordinate-light">6</text>
+    <text x=".75" y="40.75" font-size="2.8" class="coordinate-dark">5</text>
+    <text x=".75" y="53.25" font-size="2.8" class="coordinate-light">4</text>
+    <text x=".75" y="65.75" font-size="2.8" class="coordinate-dark">3</text>
+    <text x=".75" y="78.25" font-size="2.8" class="coordinate-light">2</text>
+    <text x=".75" y="90.75" font-size="2.8" class="coordinate-dark">1</text>
+    <text x="10" y="99" font-size="2.8" class="coordinate-dark">a</text>
+    <text x="22.5" y="99" font-size="2.8" class="coordinate-light">b</text>
+    <text x="35" y="99" font-size="2.8" class="coordinate-dark">c</text>
+    <text x="47.5" y="99" font-size="2.8" class="coordinate-light">d</text>
+    <text x="60" y="99" font-size="2.8" class="coordinate-dark">e</text>
+    <text x="72.5" y="99" font-size="2.8" class="coordinate-light">f</text>
+    <text x="85" y="99" font-size="2.8" class="coordinate-dark">g</text>
+    <text x="97.5" y="99" font-size="2.8" class="coordinate-light">h</text>
+  </svg>
+</template>
+
+<style scoped lang="scss">
+.overlay {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+
+  .coordinate-light,
+  .coordinate-dark {
+    font-weight: 800;
+  }
+  .coordinate-dark {
+    fill: #eeeed2;
+  }
+  .coordinate-light {
+    fill: #779952;
+  }
+}
+</style>

--- a/src/components/FileRankInfo.vue
+++ b/src/components/FileRankInfo.vue
@@ -30,10 +30,10 @@
     font-weight: 800;
   }
   .coordinate-dark {
-    fill: #eeeed2;
+    fill: var(--chess-light);
   }
   .coordinate-light {
-    fill: #779952;
+    fill: var(--chess-dark);
   }
 }
 </style>

--- a/src/components/FileRankInfo.vue
+++ b/src/components/FileRankInfo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts"></script>
 
 <template>
-  <svg viewBox="0 0 100 100" class="overlay">
+  <svg viewBox="0 0 100 100" class="board overlay">
     <text x=".75" y="3.5" font-size="2.8" class="coordinate-light">8</text>
     <text x=".75" y="15.75" font-size="2.8" class="coordinate-dark">7</text>
     <text x=".75" y="28.25" font-size="2.8" class="coordinate-light">6</text>
@@ -22,16 +22,9 @@
 </template>
 
 <style scoped lang="scss">
+@import "@/styles/board.css";
+@import "@/styles/overlay.css";
 .overlay {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  pointer-events: none;
-
   .coordinate-light,
   .coordinate-dark {
     font-weight: 800;

--- a/src/components/HighlightBoard.vue
+++ b/src/components/HighlightBoard.vue
@@ -9,7 +9,7 @@ function key(square: Coordinate) {
 </script>
 
 <template>
-  <div class="board highlight">
+  <div class="board overlay">
     <HighlightSquare
       v-for="square in store.highlighted"
       :key="key(square)"
@@ -20,15 +20,5 @@ function key(square: Coordinate) {
 
 <style scoped>
 @import "@/styles/board.css";
-
-.highlight {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  pointer-events: none;
-}
+@import "@/styles/overlay.css";
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -3,6 +3,8 @@
   --light-secondary: #c7c6c5;
   --dark-main: #312e2b;
   --dark-secondary: #272522;
+  --chess-light: #eeeed2;
+  --chess-dark: #769656;
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;

--- a/src/styles/overlay.css
+++ b/src/styles/overlay.css
@@ -1,0 +1,10 @@
+.overlay {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Description
Adds the side information on the board showing the Rank and the File.
We are taking advantage of the fact that these are static and don't handle any click events and simply display them using an inline SVG. (I might have shamelessly used the same one as [Chess.com](https://chess.com/analysis))

We are also making use of the same classes we used for the highlight overlay.
This overlay class is now extracted so in the future we could use it for drawing pieces for example.

Lastly, the chess board colors have been extracted to global variables for easy modification/theming.

## Screenshot
<img width="953" alt="imagen" src="https://user-images.githubusercontent.com/3190666/236943639-a7e9d2d7-a064-4023-8f92-3d6293e1f334.png">
