### PR TITLE
Add Reset Button

### DIFF
--- a/src/components/ClickedHistory.vue
+++ b/src/components/ClickedHistory.vue
@@ -9,6 +9,9 @@ const displayCoordinate = (square: Coordinate) =>
 <template>
   <div class="container">
     <h3>Square History</h3>
+    <div class="toolbar">
+      <button class="button">Reset</button>
+    </div>
     <ol>
       <li
         v-for="square in store.highlighted"
@@ -26,14 +29,39 @@ const displayCoordinate = (square: Coordinate) =>
   padding: 8px;
   box-sizing: border-box;
   max-height: 100vh;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 h3 {
-  margin-top: 0;
+  margin: 0;
 }
 ol {
   margin: 0;
+  flex: 1;
+  height: 100%;
+  overflow-y: auto;
 }
+
+.toolbar {
+  padding: 8px;
+  margin-bottom: 8px;
+}
+.button {
+  background-color: #95bb4a;
+  color: white;
+  width: 100%;
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-size: 1.3rem;
+  font-weight: 800;
+  line-height: 1.2;
+  text-shadow: 0 0.1rem 0 rgba(0, 0, 0, 0.4);
+  padding: 0.6rem;
+
+  border: 0;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.25rem 0 0 #537133;
+}
+
 .notation {
   font-weight: bolder;
 }
@@ -41,7 +69,6 @@ ol {
 @media (max-aspect-ratio: 1/1) {
   .container {
     max-height: 100%;
-    overflow-y: unset;
   }
 }
 </style>

--- a/src/components/ClickedHistory.vue
+++ b/src/components/ClickedHistory.vue
@@ -4,13 +4,17 @@ import { Coordinate } from "@/types";
 
 const displayCoordinate = (square: Coordinate) =>
   `${square.file}${square.rank}`;
+
+const reset = () => {
+  store.reset();
+};
 </script>
 
 <template>
   <div class="container">
     <h3>Square History</h3>
     <div class="toolbar">
-      <button class="button">Reset</button>
+      <button class="button" @click="reset">Reset</button>
     </div>
     <ol>
       <li

--- a/src/components/ClickedHistory.vue
+++ b/src/components/ClickedHistory.vue
@@ -35,20 +35,30 @@ const reset = () => {
   max-height: 100vh;
   display: flex;
   flex-direction: column;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 h3 {
   margin: 0;
+  order: 1;
 }
 ol {
   margin: 0;
   flex: 1;
   height: 100%;
   overflow-y: auto;
+  order: 2;
 }
 
 .toolbar {
   padding: 8px;
   margin-bottom: 8px;
+  order: 3;
 }
 .button {
   background-color: #95bb4a;
@@ -75,8 +85,11 @@ ol {
 }
 
 @media (max-aspect-ratio: 1/1) {
-  .container {
-    max-height: 100%;
+  .toolbar {
+    order: 2;
+  }
+  ol {
+    order: 3;
   }
 }
 </style>

--- a/src/components/ClickedHistory.vue
+++ b/src/components/ClickedHistory.vue
@@ -14,7 +14,7 @@ const reset = () => {
   <div class="container">
     <h3>Square History</h3>
     <div class="toolbar">
-      <button class="button" @click="reset">Reset</button>
+      <button class="button" ontouchstart="" @click="reset">Reset</button>
     </div>
     <ol>
       <li
@@ -64,6 +64,10 @@ ol {
   border: 0;
   border-radius: 0.5rem;
   box-shadow: 0 0.25rem 0 0 #537133;
+}
+.button:active {
+  transform: translateY(0.15rem);
+  box-shadow: 0 0.1rem 0 0 #537133;
 }
 
 .notation {

--- a/src/components/HighlightBoard.vue
+++ b/src/components/HighlightBoard.vue
@@ -11,7 +11,7 @@ function key(square: Coordinate) {
 <template>
   <div class="board overlay">
     <HighlightSquare
-      v-for="square in store.highlighted"
+      v-for="square in store.highlighted.slice(-1)"
       :key="key(square)"
       v-bind="square"
     />

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -12,6 +12,7 @@ import ClickedHistory from "./ClickedHistory.vue";
 .sidebar {
   background-color: var(--dark-secondary);
   height: 100%;
+  position: relative;
 }
 @media (prefers-color-scheme: light) {
   .sidebar {

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,11 +4,15 @@ import { Coordinate } from "./types";
 type storeType = {
   highlighted: Array<Coordinate>;
   addHighlight: (coordinate: Coordinate) => void;
+  reset: () => void;
 };
 
 export const store = reactive<storeType>({
   highlighted: [],
   addHighlight(coordinate: Coordinate) {
     this.highlighted.push(coordinate);
+  },
+  reset() {
+    this.highlighted = [];
   },
 });


### PR DESCRIPTION
## Description
After refreshing countless times, I added a nice Reset button that might look somewhat similar to the ones I saw at [Chess.com](https://www.chess.com/play/online). When you press the button it resets the clicked squares list.

The button positions itself at the bottom on desktop and a little bit higher up on mobile.

Additionally, I added some extra styling to prevent the square history from overflowing to the bottom on mobile.

I did add one extra QoL improvement which makes it that only the last square is highlighted, because now we finally have the list of clicked squares.

## Screenshot
![May-08-2023 17-32-59](https://user-images.githubusercontent.com/3190666/236952074-1170d716-b4f0-49eb-82c1-42eb7517e8fe.gif)
