### PR TITLE
Scroll to bottom of list after adding a clicked square

### DIFF
--- a/src/components/ClickedHistory.vue
+++ b/src/components/ClickedHistory.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { store } from "@/store.ts";
 import { Coordinate } from "@/types";
+import { ref, watch } from "vue";
 
 const displayCoordinate = (square: Coordinate) =>
   `${square.file}${square.rank}`;
@@ -8,6 +9,15 @@ const displayCoordinate = (square: Coordinate) =>
 const reset = () => {
   store.reset();
 };
+
+const list = ref<HTMLElement | null>(null);
+
+watch(store.highlighted, (_) => {
+  const listElement = list.value!;
+  setTimeout(() => {
+    listElement.scrollTo(0, listElement.scrollHeight);
+  }, 0);
+});
 </script>
 
 <template>
@@ -16,7 +26,7 @@ const reset = () => {
     <div class="toolbar">
       <button class="button" ontouchstart="" @click="reset">Reset</button>
     </div>
-    <ol>
+    <ol ref="list">
       <li
         v-for="square in store.highlighted"
         v-bind="square"

--- a/src/components/ClickedHistory.vue
+++ b/src/components/ClickedHistory.vue
@@ -13,7 +13,10 @@ const reset = () => {
 const list = ref<HTMLElement | null>(null);
 
 watch(store.highlighted, (_) => {
-  const listElement = list.value!;
+  if (list.value === null) {
+    return;
+  }
+  const listElement = list.value;
   setTimeout(() => {
     listElement.scrollTo(0, listElement.scrollHeight);
   }, 0);


### PR DESCRIPTION
## Description
Improves UX by auto scrolling the history list to the bottom when we add a square to the clicked square list.

### Implementation details
I made use of the Reactivity API's [watch](https://vuejs.org/api/reactivity-core.html#watch). This allows us to run a callback when the value changes. I had to use a `setTimeout` with a `0` delay to effectively scroll AFTER the added element is rendered.

## Screenshot
Before ⚠️ :
![May-08-2023 18-06-57](https://user-images.githubusercontent.com/3190666/236956576-c9ae7930-99be-4293-8c6a-6a7a04dfc0fc.gif)


After ✅ :
![May-08-2023 18-08-40](https://user-images.githubusercontent.com/3190666/236956558-06eac767-0256-4ccb-bc77-9d2540d443ce.gif)
